### PR TITLE
Use IIS Express

### DIFF
--- a/Excella.Vending.Web.UI/Excella.Vending.Web.UI.csproj
+++ b/Excella.Vending.Web.UI/Excella.Vending.Web.UI.csproj
@@ -17,7 +17,7 @@
     <AssemblyName>Excella.Vending.Web.UI</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
-    <UseIISExpress>false</UseIISExpress>
+    <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
@@ -217,7 +217,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>8484</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost/Excella.Vending.Web.UI</IISUrl>
+          <IISUrl>http://localhost:8484/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
@@ -11,7 +11,7 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
     public class BuyProductSteps
     {
         private const int IIS_PORT = 8484;
-        private const string APPLICATION_NAME = "Excella.Vending.Web.UI"; //TODO
+        private const string APPLICATION_NAME = "Excella.Vending.Web.UI";
         private HomePage _homePage;
         private int _previousBalance;
 
@@ -58,7 +58,7 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
 
         [BeforeScenario]
         public void Setup()
-        { 
+        {
             _homePage = new HomePage();
             _homePage.Go();
         }

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
@@ -25,6 +25,7 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
         public static void AfterFeature()
         {
             StopIIS();
+            //TODO: Release change to put the value back for the sake of other tests.
         }
 
         private static void StopIIS()

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
@@ -44,15 +44,24 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
             var applicationPath = GetApplicationPath(APPLICATION_NAME);
             var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
 
-            var iisProcess = new Process();
-            iisProcess.StartInfo.FileName = programFiles + @"\IIS Express\iisexpress.exe";
-            iisProcess.StartInfo.Arguments = string.Format("/path:\"{0}\" /port:{1}", applicationPath, IIS_PORT);
+            var startInfoFileName = programFiles + @"\IIS Express\iisexpress.exe";
+            var startInfoArguments = $"/path:\"{applicationPath}\" /port:{IIS_PORT}";
+
+            var iisProcess = new Process
+            {
+                StartInfo =
+                {
+                    FileName = startInfoFileName,
+                    Arguments = startInfoArguments
+                }
+            };
             iisProcess.Start();
         }
 
         private static string GetApplicationPath(string applicationName)
         {
-            var solutionFolder = Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory)));
+            var solutionFolder = Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory);
+            // ReSharper disable once AssignNullToNotNullAttribute -- test will fail if it's null.
             return Path.Combine(solutionFolder, applicationName);
         }
 

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
@@ -1,14 +1,60 @@
-﻿using NUnit.Framework;
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using NUnit.Framework;
 using TechTalk.SpecFlow;
+// ReSharper disable UnusedMember.Global -- test methods are said to be unused which isn't correct. -SK
 
 namespace Tests.Acceptance.Web.Excella.Vending.Machine
 {
     [Binding]
     public class BuyProductSteps
     {
-
+        private const int IIS_PORT = 8484;
+        private const string APPLICATION_NAME = "Excella.Vending.Web.UI"; //TODO
         private HomePage _homePage;
         private int _previousBalance;
+
+        [BeforeFeature]
+        public static void BeforeFeature()
+        {
+            StartIIS();
+        }
+
+        [AfterFeature]
+        public static void AfterFeature()
+        {
+            StopIIS();
+        }
+
+        private static void StopIIS()
+        {
+            var localIISExpressProcesses = Process.GetProcessesByName("iisexpress");
+            foreach (var iisExpressProcess in localIISExpressProcesses)
+            {
+                if (!iisExpressProcess.HasExited)
+                {
+                    iisExpressProcess.Kill();
+                }
+            }
+        }
+
+        private static void StartIIS()
+        {
+            var applicationPath = GetApplicationPath(APPLICATION_NAME);
+            var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+
+            var iisProcess = new Process();
+            iisProcess.StartInfo.FileName = programFiles + @"\IIS Express\iisexpress.exe";
+            iisProcess.StartInfo.Arguments = string.Format("/path:\"{0}\" /port:{1}", applicationPath, IIS_PORT);
+            iisProcess.Start();
+        }
+
+        private static string GetApplicationPath(string applicationName)
+        {
+            var solutionFolder = Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory)));
+            return Path.Combine(solutionFolder, applicationName);
+        }
 
         [BeforeScenario]
         public void Setup()

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/Class1.cs
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/Class1.cs
@@ -25,7 +25,7 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
             _browser.Close();
             _browser.Dispose();
         }
-        const string HOME_PAGE_URL = "http://localhost/Excella.Vending.Web.UI";
+        const string HOME_PAGE_URL = "http://localhost:8484/";
         public void Go()
         {
             _browser.Navigate().GoToUrl(HOME_PAGE_URL);

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/Tests.Acceptance.Web.Excella.Vending.Machine.csproj
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/Tests.Acceptance.Web.Excella.Vending.Machine.csproj
@@ -84,6 +84,9 @@
       <Name>Excella.Vending.Machine</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/Tests.Acceptance.Web.Excella.Vending.Machine.v2.ncrunchproject
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/Tests.Acceptance.Web.Excella.Vending.Machine.v2.ncrunchproject
@@ -24,7 +24,4 @@
   <UseCPUArchitecture>AutoDetect</UseCPUArchitecture>
   <MSTestThreadApartmentState>STA</MSTestThreadApartmentState>
   <BuildProcessArchitecture>x86</BuildProcessArchitecture>
-  <IgnoredTests>
-    <AllTestsSelector />
-  </IgnoredTests>
 </ProjectConfiguration>

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/Tests.Acceptance.Web.Excella.Vending.Machine.v2.ncrunchproject
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/Tests.Acceptance.Web.Excella.Vending.Machine.v2.ncrunchproject
@@ -24,4 +24,9 @@
   <UseCPUArchitecture>AutoDetect</UseCPUArchitecture>
   <MSTestThreadApartmentState>STA</MSTestThreadApartmentState>
   <BuildProcessArchitecture>x86</BuildProcessArchitecture>
+  <IgnoredTests>
+    <NamedTestSelector>
+      <TestName>Tests.Acceptance.Web.Excella.Vending.Machine.BuyProductFeature.BalanceIsUpdatedOnCoinInsert</TestName>
+    </NamedTestSelector>
+  </IgnoredTests>
 </ProjectConfiguration>


### PR DESCRIPTION
Resolves #17.

## Problem
* We can't use IIS Express via F5 (can't run tests alongside it)
* Deploying to the full edition of IIS requires a ton of setup (permissions, directories, feature installs, etc.)

## Solution
We start the IISExpress process within our test setup and kill it after the tests are finished

## Result
This takes a lot of setup out of the process:

* No need to configure IIS as a feature
* No need to deploy to a different directory
* No need to manage app pools and permissions on folders
* No need to have permission to access the IIS metabase.

## Verifications
:white_check_mark: Verified `iisexpress.exe` is started prior to tests
:white_check_mark: Verified tests pass when run
:white_check_mark: Verified all `IISexpress.exe` instances are closed when tests run
:white_check_mark: Verified this works even when the site has never been deployed to IIS Proper.